### PR TITLE
xapi-client also requires xapi-data-fixtures.

### DIFF
--- a/Client/README.md
+++ b/Client/README.md
@@ -21,11 +21,12 @@ The recommended way to install the xAPI client is using
    For more details on how to install composer have a look at the official
    [documentation](http://getcomposer.org/doc/00-intro.md).
 
-1. Add ``xabbuh/xapi-client``, ``xabbuh/xapi-common``, ``xabbuh/xapi-model`` and
+1. Add ``xabbuh/xapi-client``, ``xabbuh/xapi-data-fixtures``, ``xabbuh/xapi-common``, ``xabbuh/xapi-model`` and
    ``xabbuh/xapi-serializer`` as dependencies to your project:
 
     ```bash
     $ composer require --no-update xabbuh/xapi-client "~1.0@dev"
+    $ composer require --no-update xabbuh/xapi-data-fixtures "~1.0@dev"
     $ composer require --no-update xabbuh/xapi-common "~1.0@dev"
     $ composer require --no-update xabbuh/xapi-model "~1.0@dev"
     $ composer require xabbuh/xapi-serializer "~1.0@dev"


### PR DESCRIPTION
Ensuring the documentation reflects that.